### PR TITLE
Fix issue with language configuration

### DIFF
--- a/tinymce/tests/test_widgets.py
+++ b/tinymce/tests/test_widgets.py
@@ -47,7 +47,7 @@ class TestWidgets(TestCase):
         }
         self.assertEqual(config, config_ok)
 
-    @override_settings(LANGUAGE_CODE='pt-br')
+    @override_settings(LANGUAGE_CODE="pt-br")
     def test_default_config(self):
         config = get_language_config()
         config_ok = {

--- a/tinymce/tests/test_widgets.py
+++ b/tinymce/tests/test_widgets.py
@@ -27,7 +27,7 @@ class TestWidgets(TestCase):
         config_ok = {
             "spellchecker_languages": "+English=en",
             "directionality": "ltr",
-            "language": "en",
+            "language": "en_US",
             "spellchecker_rpc_url": "/tinymce/spellchecker/",
         }
         self.assertEqual(config, config_ok)
@@ -42,7 +42,18 @@ class TestWidgets(TestCase):
         config_ok = {
             "spellchecker_languages": "+English=en",
             "directionality": "rtl",
-            "language": "en",
+            "language": "en_US",
+            "spellchecker_rpc_url": "/tinymce/spellchecker/",
+        }
+        self.assertEqual(config, config_ok)
+
+    @override_settings(LANGUAGE_CODE='pt-br')
+    def test_default_config(self):
+        config = get_language_config()
+        config_ok = {
+            "spellchecker_languages": "Inglês=en",
+            "directionality": "ltr",
+            "language": "pt_BR",
             "spellchecker_rpc_url": "/tinymce/spellchecker/",
         }
         self.assertEqual(config, config_ok)
@@ -52,7 +63,7 @@ class TestWidgets(TestCase):
         config_ok = {
             "spellchecker_languages": "English=en",
             "directionality": "ltr",
-            "language": "en",
+            "language": "en_US",
             "spellchecker_rpc_url": "/tinymce/spellchecker/",
         }
         self.assertEqual(config, config_ok)

--- a/tinymce/tests/test_widgets.py
+++ b/tinymce/tests/test_widgets.py
@@ -48,7 +48,7 @@ class TestWidgets(TestCase):
         self.assertEqual(config, config_ok)
 
     @override_settings(LANGUAGE_CODE="pt-br")
-    def test_default_config(self):
+    def test_config_foreign_language(self):
         config = get_language_config()
         config_ok = {
             "spellchecker_languages": "Inglês=en",

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -127,7 +127,7 @@ def get_language_config(content_language=None):
     if content_language:
         content_language = content_language[:2]
     else:
-        content_language = language
+        content_language = language[:2]
 
     config = {}
     config["language"] = language

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -159,6 +159,15 @@ def get_language_config(content_language=None):
 
 
 def parse_language(lang: str) -> str:
+    """If language code is in format xx-yy, convert it into xx_YY.
+    Otherwise just return unchanged language code. 
+
+    Args:
+        lang (str): The language code to be parsed.
+
+    Returns:
+        str: Converted or unchanged language code.
+    """
     try:
         language, dialect = lang.split('-')
         return f"{language}_{dialect.upper()}"

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -123,7 +123,9 @@ class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
 
 def get_language_config(content_language=None):
     language = get_language()
-    language = language[:2] if language is not None else "en"
+    language = parse_language(language) if language is not None else "en"
+    if tinymce.settings.DEFAULT_CONFIG.get('language'):
+        language = tinymce.settings.DEFAULT_CONFIG['language']
     if content_language:
         content_language = content_language[:2]
     else:
@@ -156,3 +158,11 @@ def get_language_config(content_language=None):
         config["spellchecker_rpc_url"] = reverse("tinymce-spellcheck")
 
     return config
+
+
+def parse_language(lang: str) -> str:
+    try:
+        language, dialect = lang.split('-')
+        return f"{language}_{dialect.upper()}"
+    except ValueError:
+        return lang

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -123,7 +123,7 @@ class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
 
 def get_language_config(content_language=None):
     language = get_language()
-    language = parse_language(language) if language is not None else "en"
+    language = parse_language(language) if language is not None else "en_US"
     if content_language:
         content_language = content_language[:2]
     else:
@@ -160,7 +160,7 @@ def get_language_config(content_language=None):
 
 def parse_language(lang: str) -> str:
     """If language code is in format xx-yy, convert it into xx_YY.
-       Otherwise just return unchanged language code. 
+       Otherwise just return unchanged language code.
 
     Args:
         lang (str): The language code to be parsed.

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -160,7 +160,7 @@ def get_language_config(content_language=None):
 
 def parse_language(lang: str) -> str:
     """If language code is in format xx-yy, convert it into xx_YY.
-    Otherwise just return unchanged language code. 
+       Otherwise just return unchanged language code. 
 
     Args:
         lang (str): The language code to be parsed.
@@ -169,7 +169,7 @@ def parse_language(lang: str) -> str:
         str: Converted or unchanged language code.
     """
     try:
-        language, dialect = lang.split('-')
+        language, dialect = lang.split("-")
         return f"{language}_{dialect.upper()}"
     except ValueError:
         return lang

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -124,8 +124,6 @@ class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
 def get_language_config(content_language=None):
     language = get_language()
     language = parse_language(language) if language is not None else "en"
-    if tinymce.settings.DEFAULT_CONFIG.get('language'):
-        language = tinymce.settings.DEFAULT_CONFIG['language']
     if content_language:
         content_language = content_language[:2]
     else:


### PR DESCRIPTION
The language file name is currently being retrieved/built from the `LANGUAGE_CODE` setting or more specifically from `django.utils.translation.get_language()`, and then being parsed by `widgets.py` line 126 (`language = language[:2] if language is not None else "en"`).
_**This does not work anymore with the new file structure, and generates a bug.** I.e. `fr_FR.js`, `pt_PT.js` cannot be used._

For that reason this pull request is changing the `language` standards of the project to `xx_YY`, where xx is the language and YY is the dialect, to be in sync with naming convention on translation files of TinyMCE5.