### PR TITLE
Add feature to override language through configurations

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -169,7 +169,7 @@ Example::
       "fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | "
       "a11ycheck ltr rtl | showcomments addcomment code",
       "custom_undo_redo_levels": 10,
-      "language": "es_ES", # To force a specific language instead of the Django current LANGUAGE_CODE.
+      "language": "es_ES", # To force a specific language instead of the Django current language.
   }
   TINYMCE_SPELLCHECKER = True
   TINYMCE_COMPRESSOR = True

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -129,6 +129,8 @@ file.
   The default TinyMCE configuration to use. See `the TinyMCE manual`_ for all
   options. To set the configuration for a specific TinyMCE editor, see the
   ``mce_attrs`` parameter for the :ref:`widget <widget>`.
+  !Important: ``language`` attribute should only be set to force TinyMCE to have a 
+  different language than Django's LANGUAGE_CODE setting.
 
 ``TINYMCE_SPELLCHECKER`` (default: ``False``)
   Whether to use the spell checker through the supplied view. You must add
@@ -167,7 +169,7 @@ Example::
       "fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | "
       "a11ycheck ltr rtl | showcomments addcomment code",
       "custom_undo_redo_levels": 10,
-      "language": "es_ES",
+      "language": "es_ES", # To force a specific language instead of the Django current LANGUAGE_CODE.
   }
   TINYMCE_SPELLCHECKER = True
   TINYMCE_COMPRESSOR = True

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -129,7 +129,7 @@ file.
   The default TinyMCE configuration to use. See `the TinyMCE manual`_ for all
   options. To set the configuration for a specific TinyMCE editor, see the
   ``mce_attrs`` parameter for the :ref:`widget <widget>`.
-  !Important: ``language`` attribute should only be set to force TinyMCE to have a 
+  !Important: ``language`` attribute should only be set to force TinyMCE to have a
   different language than Django's LANGUAGE_CODE setting.
 
 ``TINYMCE_SPELLCHECKER`` (default: ``False``)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -167,6 +167,7 @@ Example::
       "fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | "
       "a11ycheck ltr rtl | showcomments addcomment code",
       "custom_undo_redo_levels": 10,
+      "language": "es_ES",
   }
   TINYMCE_SPELLCHECKER = True
   TINYMCE_COMPRESSOR = True

--- a/tinymce/tests/test_widgets.py
+++ b/tinymce/tests/test_widgets.py
@@ -58,6 +58,14 @@ class TestWidgets(TestCase):
                 config = get_language_config()
                 self.assertEqual(config["language"], lang_expected)
 
+    def test_language_override_from_config(self):
+        langs = ["es_ES", "ru"]
+        for lang in langs:
+            tinymce.settings.DEFAULT_CONFIG.update(language=lang)
+            config = get_language_config()
+            self.assertEqual(config["language"], lang)
+        tinymce.settings.DEFAULT_CONFIG.pop("language")
+
     def test_content_language(self):
         config = get_language_config("ru-ru")
         config_ok = {

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -119,6 +119,8 @@ class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
 def get_language_config(content_language=None):
     language = get_language()
     language = to_locale(language) if language is not None else "en_US"
+    if tinymce.settings.DEFAULT_CONFIG.get("language"):
+        language = tinymce.settings.DEFAULT_CONFIG["language"]
     if content_language:
         content_language = content_language[:2]
     else:

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -117,8 +117,11 @@ class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
 
 
 def get_language_config(content_language=None):
-    language = get_language()
-    language = to_locale(language) if language is not None else "en_US"
+    if tinymce.settings.DEFAULT_CONFIG.get("language"):
+        language = tinymce.settings.DEFAULT_CONFIG["language"]
+    else:
+        language = get_language()
+        language = to_locale(language) if language is not None else "en_US"
     if tinymce.settings.DEFAULT_CONFIG.get("language"):
         language = tinymce.settings.DEFAULT_CONFIG["language"]
     if content_language:


### PR DESCRIPTION
Since the `language` property on `TINYMCE_DEFAULT_CONFIG` was never being used and was always being overwritten by Django's `LANGUAGE_CODE`, I've also updated `get_language_config()` to take into consideration `TINYMCE_DEFAULT_CONFIG.language` with a higher priority than `LANGUAGE_CODE`.
This way, if an user is not satisfied with the automatic language selection from Django's Settings, he can always update the `language` property on `TINYMCE_DEFAULT_CONFIG` to change language configurations, which was not possible before.

Tests and Docs updated accordingly.