### PR TITLE
Added django-filebrowser compatibility to tinymce-v5

### DIFF
--- a/tinymce/templates/tinymce/filebrowser.js
+++ b/tinymce/templates/tinymce/filebrowser.js
@@ -1,39 +1,17 @@
-function djangoFileBrowser(field_name, url, type, win) {
-    if (tinyMCE.majorVersion >= 4) {
-        var url = "{{ fb_url }}?pop=4&type=" + type;
+function djangoFileBrowser(callback, value, meta) {
+    var url = "{{ fb_url }}?pop=5&type=" + meta.filetype;
 
-        tinyMCE.activeEditor.windowManager.open(
-            {
-                'file': url,
-                'width': 820,
-                'height': 500,
-            },
-            {
-                'window': win,
-                'input': field_name,
+    tinyMCE.activeEditor.windowManager.openUrl(
+        {
+            'title': 'Django Filebrowser',
+            'url': url,
+            'width': 1024,
+            'height': 800,
+            'onMessage': function (dialogApi, details) {
+                callback(details.content)
+                dialogApi.close()
             }
-        );
-        return false;
-    }
-    else {
-        var url = "{{ fb_url }}?pop=2&type=" + type;
-
-        tinyMCE.activeEditor.windowManager.open(
-            {
-                'file': url,
-                'width': 820,
-                'height': 500,
-                'resizable': "yes",
-                'scrollbars': "yes",
-                'inline': "no",
-                'close_previous': "no"
-            },
-            {
-                'window': win,
-                'input': field_name,
-                'editor_id': tinyMCE.selectedInstance.editorId
-            }
-        );
-        return false;
-    }
+        },
+    );
+    return false
 }

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -61,7 +61,7 @@ class TinyMCE(forms.Textarea):
         mce_config["language"] = match_language_with_tinymce(mce_config["language"])
         mce_config.update(get_language_config(self.content_language or mce_config["language"]))
         if tinymce.settings.USE_FILEBROWSER:
-            mce_config["file_browser_callback"] = "djangoFileBrowser"
+            mce_config["file_picker_callback"] = "djangoFileBrowser"
         mce_config.update(self.mce_attrs)
         if mce_config["mode"] == "exact":
             mce_config["elements"] = attrs["id"]


### PR DESCRIPTION
Fixed django-filebrowser compatibility as requested in Issue #303 


There is a similar pull-request in the https://github.com/smacker/django-filebrowser-no-grappelli repo containing the nessesary patches on the side of django-filebrowser