### PR TITLE
Changed force_text() to force_str()

### DIFF
--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -7,7 +7,6 @@ import logging
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -28,8 +27,7 @@ def spell_check(request):
         if not enchant:
             raise RuntimeError("install pyenchant for spellchecker functionality")
 
-        raw = force_str(request.body)
-        input = json.loads(raw)
+        input = json.loads(request.body)
         id = input["id"]
         method = input["method"]
         params = input["params"]

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -7,7 +7,7 @@ import logging
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -28,7 +28,7 @@ def spell_check(request):
         if not enchant:
             raise RuntimeError("install pyenchant for spellchecker functionality")
 
-        raw = force_text(request.body)
+        raw = force_str(request.body)
         input = json.loads(raw)
         id = input["id"]
         method = input["method"]

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.forms.utils import flatatt
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext as _, to_locale
@@ -75,7 +75,7 @@ class TinyMCE(forms.Textarea):
     def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ""
-        value = force_text(value)
+        value = force_str(value)
         final_attrs = self.build_attrs(self.attrs, attrs)
         final_attrs["name"] = name
         if final_attrs.get("class", None) is None:

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.forms.utils import flatatt
 from django.urls import reverse
-from django.utils.encoding import force_str
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext as _, to_locale
@@ -75,7 +74,6 @@ class TinyMCE(forms.Textarea):
     def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ""
-        value = force_str(value)
         final_attrs = self.build_attrs(self.attrs, attrs)
         final_attrs["name"] = name
         if final_attrs.get("class", None) is None:


### PR DESCRIPTION
force_text() will be removed in Django 4.0 and is deprecated in favor of force_str()