### PR TITLE
Fixed the spellchecker view as per tinymce doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 3.4.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed the bug in spellchecker.
 
 
 3.3.0 (2021-03-24)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,6 @@
-import json
 import os
 from unittest.mock import Mock, patch
+from urllib.parse import urlencode
 
 from django.contrib.flatpages.models import FlatPage
 from django.http import HttpResponse
@@ -20,58 +20,68 @@ class TestViews(TestCase):
     @patch("tinymce.views.enchant")
     def test_spell_check_words(self, enchant_mock):
         checker_mock = Mock()
-        checker_mock.check.return_value = False
+        checker_mock.check.return_value = True
         enchant_mock.Dict.return_value = checker_mock
 
-        body = json.dumps({"id": "test", "method": "checkWords", "params": ["en", ["test"]]})
+        body = urlencode({"method": "spellcheck", "text": "tesat", "lang": "en"})
         response = self.client.post(
-            "/tinymce/spellchecker/", body, content_type="application/json"
+            "/tinymce/spellchecker/", body, content_type="application/x-www-form-urlencoded"
         )
 
-        output = {
-            "id": "test",
-            "result": ["test"],
-            "error": None,
-        }
+        output = {"words": {}}
+
         self.assertEqual(200, response.status_code)
         self.assertEqual("application/json", response["Content-Type"])
         self.assertEqual(output, response.json())
 
     @patch("tinymce.views.enchant")
     def test_spell_check_suggest(self, enchant_mock):
-        result = ["test"]
+        result = ["sample"]
         checker_mock = Mock()
+        checker_mock.check.return_value = False
         checker_mock.suggest.return_value = result
         enchant_mock.Dict.return_value = checker_mock
 
-        body = json.dumps({"id": "test", "method": "getSuggestions", "params": ["en", "test"]})
+        body = urlencode({"method": "spellcheck", "text": "smaple", "lang": "en"})
         response = self.client.post(
-            "/tinymce/spellchecker/", body, content_type="application/json"
+            "/tinymce/spellchecker/", body, content_type="application/x-www-form-urlencoded"
         )
-        output = {
-            "id": "test",
-            "result": result,
-            "error": None,
-        }
+
+        output = {"words": {"smaple": ["sample"]}}
+
         self.assertEqual(200, response.status_code)
         self.assertEqual("application/json", response["Content-Type"])
         self.assertEqual(output, response.json())
 
     @patch("tinymce.views.enchant")
-    def test_spell_check_unknown(self, enchant_mock):
-        checker_mock = Mock()
-        checker_mock.suggest.return_value = ["test"]
-        enchant_mock.Dict.return_value = checker_mock
-
-        body = json.dumps({"id": "test", "method": "test", "params": ["en", "test"]})
+    def test_spell_check_unknown_method(self, enchant_mock):
+        body = urlencode({"method": "test", "text": "test", "lang": "en"})
         with patch("sys.stderr", devnull):
             response = self.client.post(
-                "/tinymce/spellchecker/", body, content_type="application/json"
+                "/tinymce/spellchecker/", body, content_type="application/x-www-form-urlencoded"
             )
-        result_ok = b"Error running spellchecker"
+
+        output = {"error": "Got an unexpected method 'test'"}
+
         self.assertEqual(200, response.status_code)
-        self.assertEqual("text/html; charset=utf-8", response["Content-Type"])
-        self.assertEqual(result_ok, response.content)
+        self.assertEqual("application/json", response["Content-Type"])
+        self.assertEqual(output, response.json())
+
+    @patch("tinymce.views.enchant")
+    def test_spell_check_unknown_lang(self, enchant_mock):
+        enchant_mock.dict_exists.return_value = False
+
+        body = urlencode({"method": "spellcheck", "text": "test", "lang": "en"})
+        with patch("sys.stderr", devnull):
+            response = self.client.post(
+                "/tinymce/spellchecker/", body, content_type="application/x-www-form-urlencoded"
+            )
+
+        output = {"error": "Dictionary not found for language 'en', check pyenchant."}
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response["Content-Type"])
+        self.assertEqual(output, response.json())
 
     def test_flatpages_link_list(self):
         FlatPage.objects.create(

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -7,7 +7,6 @@ import logging
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 
 from tinymce.compressor import gzip_compressor
@@ -27,32 +26,41 @@ def spell_check(request):
         if not enchant:
             raise RuntimeError("install pyenchant for spellchecker functionality")
 
-        input = json.loads(request.body)
-        id = input["id"]
-        method = input["method"]
-        params = input["params"]
-        lang = params[0]
-        arg = params[1]
+        method = request.POST.get("method")
+        text = request.POST.get("text")
+        lang = request.POST.get("lang")
 
         if not enchant.dict_exists(str(lang)):
-            raise RuntimeError(f"dictionary not found for language {lang}")
+            e_msg = f"Dictionary not found for language '{lang}', check pyenchant."
+            raise RuntimeError(e_msg)
 
         checker = enchant.Dict(str(lang))
 
-        if method == "checkWords":
-            result = [word for word in arg if word and not checker.check(word)]
-        elif method == "getSuggestions":
-            result = checker.suggest(arg)
+        def sanitize_word(text):
+            """Sanitize the words and reccommend suggestion for word
+            fix.
+            """
+            suggested_words = {}
+            words = text.split()
+            for word in words:
+                word.strip()
+                word.strip(".,:;'\"")
+                if not checker.check(word):
+                    suggested_words[word] = checker.suggest(word)
+            return suggested_words
+
+        if method == "spellcheck":
+            if text:
+                words = sanitize_word(text)
+            output = {"words": words}
         else:
-            raise RuntimeError(f"Unknown spellcheck method: {method}")
-        output = {
-            "id": id,
-            "result": result,
-            "error": None,
-        }
-    except Exception:
+            e_msg = f"Got an unexpected method '{method}'"
+            raise RuntimeError(e_msg)
+
+    except Exception as err:
         logging.exception("Error running spellchecker")
-        return HttpResponse(_("Error running spellchecker"))
+        output = {"error": str(err)}
+
     return JsonResponse(output)
 
 


### PR DESCRIPTION
The spell checker was not conforming as per the [documentation](https://www.tiny.cloud/docs/plugins/opensource/spellchecker/#spellcheckerresponseformat).  

Update the spell checker view to support it

Note:
The data received is in post as querystring .
Stripping out spaces and ` . , : ; ' " ` at the end and start of any word.