### PR TITLE
Add compatibility with Django 4.1 formset added event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
+- Support new non-jQuery formset:added event triggered on Django 4.1
 - Confirmed support for Django 4.0
 - Drop support for Django 3.0 and Python 3.6
 - Add Python 3.10 support

--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -53,18 +53,24 @@
     }
   }
 
+  function initializeTinyMCE(element, formsetName) {
+    Array.from(element.querySelectorAll('.tinymce')).forEach(area => initTinyMCE(area));
+  }
+
   ready(function() {
     // initialize the TinyMCE editors on load
-    document.querySelectorAll('.tinymce').forEach(function(el) {
-      initTinyMCE(el);
-    });
+    initializeTinyMCE(document);
 
     // initialize the TinyMCE editor after adding an inline in the django admin context.
     if (typeof(django) !== 'undefined' && typeof(django.jQuery) !== 'undefined') {
-      django.jQuery(document).on('formset:added', function(event, $row, formsetName) {
-        $row.find('textarea.tinymce').each(function() {
-          initTinyMCE(this);
-        });
+      django.jQuery(document).on('formset:added', (event, $row, formsetName) => {
+        if (event.detail && event.detail.formsetName) {
+          // Django >= 4.1
+          initializeTinyMCE(event.target);
+        } else {
+          // Django < 4.1, use $row
+          initializeTinyMCE($row.get(0));
+        }
       });
     }
   });


### PR DESCRIPTION
In Django 4.1, the 'formset:added' event is a native JS event.
See https://github.com/django/django/commit/eabc22f91