### PR TITLE
setup.py: Don't install the tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CHANGELOG = read_file("CHANGELOG.rst")
 setup(
     name="django-tinymce",
     version="3.5.0",
-    packages=find_packages(exclude=['tests*']),
+    packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     author="Aljosa Mohorovic",
     author_email="aljosa.mohorovic@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CHANGELOG = read_file("CHANGELOG.rst")
 setup(
     name="django-tinymce",
     version="3.5.0",
-    packages=find_packages(exclude=['tests*'])
+    packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     author="Aljosa Mohorovic",
     author_email="aljosa.mohorovic@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CHANGELOG = read_file("CHANGELOG.rst")
 setup(
     name="django-tinymce",
     version="3.5.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*'])
     include_package_data=True,
     author="Aljosa Mohorovic",
     author_email="aljosa.mohorovic@gmail.com",


### PR DESCRIPTION
Avoid the installation of the test suite in the top-level directory of Python's site-lib directory.

This should fix issue #355.