### PR TITLE
This module don't handle translated options (gettext_lazy or pgettext_lazy)

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -5,7 +5,7 @@ import django
 from django import forms
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from django.utils.translation import override
+from django.utils.translation import override, gettext_lazy
 
 import tinymce.settings
 from tinymce.widgets import TinyMCE, get_language_config
@@ -155,3 +155,11 @@ class TestWidgets(SimpleTestCase):
 
         rendered = str(TinyForm())
         self.assertNotIn("required", rendered)
+
+    def test_tinymce_widget_allow_translated_options(self):
+        widget = TinyMCE()
+        orig_config = tinymce.settings.DEFAULT_CONFIG
+        style_formats = [{'title': gettext_lazy("Awesome style"), 'inline': 'strong'}]
+        with patch.dict(tinymce.settings.DEFAULT_CONFIG, {**orig_config, "style_formats": style_formats}):
+            html = widget.render("foobar", "lorem ipsum", attrs={"id": "id_foobar"})
+            self.assertIn('Awesome style', html)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -5,7 +5,7 @@ import django
 from django import forms
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from django.utils.translation import override, gettext_lazy
+from django.utils.translation import gettext_lazy, override
 
 import tinymce.settings
 from tinymce.widgets import TinyMCE, get_language_config
@@ -159,7 +159,9 @@ class TestWidgets(SimpleTestCase):
     def test_tinymce_widget_allow_translated_options(self):
         widget = TinyMCE()
         orig_config = tinymce.settings.DEFAULT_CONFIG
-        style_formats = [{'title': gettext_lazy("Awesome style"), 'inline': 'strong'}]
-        with patch.dict(tinymce.settings.DEFAULT_CONFIG, {**orig_config, "style_formats": style_formats}):
+        style_formats = [{"title": gettext_lazy("Awesome style"), "inline": "strong"}]
+        with patch.dict(
+            tinymce.settings.DEFAULT_CONFIG, {**orig_config, "style_formats": style_formats}
+        ):
             html = widget.render("foobar", "lorem ipsum", attrs={"id": "id_foobar"})
-            self.assertIn('Awesome style', html)
+            self.assertIn("Awesome style", html)

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -13,6 +13,7 @@ import warnings
 from django import forms
 from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
+from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.utils import flatatt
 from django.urls import reverse
 from django.utils.html import escape
@@ -81,7 +82,7 @@ class TinyMCE(forms.Textarea):
             final_attrs["class"] = " ".join(final_attrs["class"].split(" ") + ["tinymce"])
         assert "id" in final_attrs, "TinyMCE widget attributes must contain 'id'"
         mce_config = self.get_mce_config(final_attrs)
-        mce_json = json.dumps(mce_config)
+        mce_json = json.dumps(mce_config, cls=DjangoJSONEncoder)
         if tinymce.settings.USE_COMPRESSOR:
             compressor_config = {
                 "plugins": mce_config.get("plugins", ""),


### PR DESCRIPTION
I would like to translate custom style names defined in TINYMCE_DEFAULT_CONFIG, but this code throws TypeError: Object of type __proxy__ is not JSON serializable

```python
'table_class_list': [
    {'title': 'None', 'value': ''},
    {'title': _('Wide'), 'value': 'u-wide'},
]
```