### PR TITLE
Revert "Fixes #420: Switch to staticfiles_storage.url() to reference JS files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
+3.6.1 (2023-03-20)
+==================
+
+- Fixed a regression by reverting usage of staticfiles to find tinymce
+  location (#420, #430).
+
 3.6.0 (2023-03-18)
 ==================
 

--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -1,5 +1,6 @@
+import os
+
 from django.conf import settings
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import AppRegistryNotReady
 
 DEFAULT_CONFIG = getattr(
@@ -32,13 +33,13 @@ USE_FILEBROWSER = getattr(
 JS_URL = getattr(
     settings,
     "TINYMCE_JS_URL",
-    staticfiles_storage.url("tinymce/tinymce.min.js"),
+    os.path.join(settings.STATIC_URL, "tinymce/tinymce.min.js"),
 )
 try:
     from django.contrib.staticfiles import finders
 
     JS_ROOT = getattr(settings, "TINYMCE_JS_ROOT", finders.find("tinymce", all=False))
 except AppRegistryNotReady:
-    JS_ROOT = getattr(settings, "TINYMCE_JS_ROOT", staticfiles_storage.url("tinymce"))
+    JS_ROOT = getattr(settings, "TINYMCE_JS_ROOT", os.path.join(settings.STATIC_ROOT, "tinymce"))
 
 JS_BASE_URL = JS_URL[: JS_URL.rfind("/")]


### PR DESCRIPTION
This reverts commit db466745ad0082931d1d4ed3d0a0894d4fdc6594. See issue #430.