### PR TITLE
Update usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,12 +27,10 @@ flatpage form you could use the following code::
   from tinymce.widgets import TinyMCE
 
   class FlatPageForm(forms.ModelForm):
-      ...
-      content = forms.CharField(widget=TinyMCE(attrs={'cols': 80, 'rows': 30}))
-      ...
 
       class Meta:
           model = FlatPage
+          widgets = {'content': TinyMCE(attrs={'cols': 80, 'rows': 30})}
 
 The widget accepts the following extra keyword argument:
 


### PR DESCRIPTION
Defining the widget in the Meta class of this ModelForm instead of as a form field makes sure the resulting widget respects model attributes such as blank=True (which it would convert to required=False for the widget).