### PR TITLE
Update init_tinymce.js

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -33,7 +33,7 @@
       if (mce_conf.selector && mce_conf.selector.includes('__prefix__')) {
         mce_conf.selector = `#${el.id}`;
       }
-      else if (!'selector' in mce_conf) {
+      else if (!('selector' in mce_conf)) {
         mce_conf['target'] = el;
       }
       if (el.dataset.mceGzConf) {


### PR DESCRIPTION
(!'selector' in mce_conf) does not properly evaluate as this will only ever return a false result even if 'selector' is not present in mce_conf. The not operator '!' needs to be applied to the entire ('selector' in mce_conf) check for it to properly evaluate.