### PR TITLE
Remove plugin "code" mentioned twice

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -11,7 +11,7 @@ DEFAULT_CONFIG = getattr(
         "browser_spellcheck": True,
         "plugins": "advlist,autolink,lists,link,image,charmap,preview,anchor,"
         "searchreplace,visualblocks,code,fullscreen,insertdatetime,media,table,"
-        "code,help,wordcount",
+        "help,wordcount",
         "toolbar": "undo redo | formatselect | "
         "bold italic backcolor | alignleft aligncenter "
         "alignright alignjustify | bullist numlist outdent indent | "


### PR DESCRIPTION
This PR removes the second occurrence of plugin "code" which is also mentioned on the previous line.