### PR TITLE
Do not attempt to load en_GB langauge

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -62,13 +62,16 @@ class TestWidgets(SimpleTestCase):
                 config = widget.get_mce_config(attrs={"id": "id"})
                 self.assertEqual(config["language"], "en_US")
 
-    def test_no_language_for_en_US(self):
+    def test_no_language_for_en(self):
         """
-        en_US shouldn't set 'language'
+        en_US nor en_GB shouldn't set 'language'
         (https://github.com/tinymce/tinymce/issues/4228)
         """
         widget = TinyMCE()
         with override_settings(LANGUAGE_CODE="en-us"):
+            config = widget.get_mce_config(attrs={"id": "id"})
+            self.assertNotIn("language", config.keys())
+        with override_settings(LANGUAGE_CODE="en-gb"):
             config = widget.get_mce_config(attrs={"id": "id"})
             self.assertNotIn("language", config.keys())
         self.assertEqual(config["directionality"], "ltr")

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -55,7 +55,7 @@ class TinyMCE(forms.Textarea):
         mce_config = tinymce.settings.DEFAULT_CONFIG.copy()
         if "language" not in mce_config:
             mce_config["language"] = get_language_from_django()
-        if mce_config["language"] == "en_US":
+        if mce_config["language"] in ["en_GB", "en_US"]:
             del mce_config["language"]
         else:
             mce_config["language"] = match_language_with_tinymce(mce_config["language"])


### PR DESCRIPTION
GH-319 only fixed the issue for en_US while it persists for en_GB.
It doesn't seem to be causing any issues, it's just seeing `Not Found: /static/tinymce/langs/en_GB.js` in the console on every page load with TinyMCE widget is annoying.

I guess it could be extended to every English language variation but I'm not an expert on that so I'd appreciate somebody else's input.
