### PR TITLE
Fix ugly HTML source editor when TinyMCE is used inside Django admin

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -84,7 +84,7 @@ TINYMCE_DEFAULT_CONFIG = {
     "toolbar": "undo redo | blocks | "
     "bold italic backcolor | alignleft aligncenter "
     "alignright alignjustify | bullist numlist outdent indent | "
-    "removeformat | help",
+    "removeformat | code | help",
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/tests/testapp/admin.py
+++ b/tests/testapp/admin.py
@@ -3,8 +3,8 @@ from django.contrib.flatpages.admin import FlatPageAdmin
 from django.contrib.flatpages.models import FlatPage
 from django.urls import reverse
 
-from tests.testapp.models import TestInline, TestPage
-from tinymce.widgets import TinyMCE
+from tests.testapp.models import TestInline, TestModel, TestPage
+from tinymce.widgets import AdminTinyMCE
 
 
 class TinyMCETestInlineAdmin(admin.StackedInline):
@@ -14,7 +14,7 @@ class TinyMCETestInlineAdmin(admin.StackedInline):
     def formfield_for_dbfield(self, db_field, **kwargs):
         if db_field.name in ("content1", "content2"):
             return db_field.formfield(
-                widget=TinyMCE(
+                widget=AdminTinyMCE(
                     attrs={"cols": 80, "rows": 30},
                     mce_attrs={"external_link_list_url": reverse("tinymce-linklist")},
                 )
@@ -26,7 +26,7 @@ class TinyMCEFlatPageAdmin(FlatPageAdmin):
     def formfield_for_dbfield(self, db_field, **kwargs):
         if db_field.name == "content":
             return db_field.formfield(
-                widget=TinyMCE(
+                widget=AdminTinyMCE(
                     attrs={"cols": 80, "rows": 30},
                     mce_attrs={"external_link_list_url": reverse("tinymce-linklist")},
                 )
@@ -40,7 +40,7 @@ class TinyMCETestPageAdmin(admin.ModelAdmin):
     def formfield_for_dbfield(self, db_field, **kwargs):
         if db_field.name in ("content1", "content2"):
             return db_field.formfield(
-                widget=TinyMCE(
+                widget=AdminTinyMCE(
                     attrs={"cols": 80, "rows": 30},
                     mce_attrs={"external_link_list_url": reverse("tinymce-linklist")},
                 )
@@ -51,3 +51,4 @@ class TinyMCETestPageAdmin(admin.ModelAdmin):
 admin.site.unregister(FlatPage)
 admin.site.register(FlatPage, TinyMCEFlatPageAdmin)
 admin.site.register(TestPage, TinyMCETestPageAdmin)
+admin.site.register(TestModel)

--- a/tinymce/static/django_tinymce/admin_tinymce.css
+++ b/tinymce/static/django_tinymce/admin_tinymce.css
@@ -1,0 +1,15 @@
+/*
+Workaround for the following rule defined in
+django/contrib/admin/static/admin/css/responsive.css (which is
+unsuitable for textareas used by TinyMCE internally):
+
+@media (max-width: 1024px) {
+    textarea {
+        max-width: 100%;
+        max-height: 120px;
+    }
+}
+*/
+.tox .tox-textarea-wrap .tox-textarea {
+    max-height: none;
+}

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -116,7 +116,13 @@ class TinyMCE(forms.Textarea):
 
 
 class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
-    pass
+    def _media(self):
+        css = {
+            "all": ["django_tinymce/admin_tinymce.css"],
+        }
+        return forms.Media(css=css) + super().media
+
+    media = property(_media)
 
 
 def get_language_from_django():


### PR DESCRIPTION
The standard CSS for the `django.contrib.admin` app contains this:
```
@media (max-width: 1024px) {
    textarea {
        max-width: 100%;
        max-height: 120px;
    }
}
```
(see https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/responsive.css)

This limits the height of the textarea used by TinyMCE's HTML source editor (the "Source Code" button), when using TinyMCE inside the Django admin app, in a 1024-pixel-or-smaller window.  Combined with TinyMCE's styling, the result is unattractive and unintuitive.

(It's likely that the same problem affects any other textareas used by TinyMCE or third-party plugins, but the "Source Code" feature is the only one I know about.)

Of course it's possible for a site to override this using custom stylesheets (though it's not totally obvious how to do so in a clean way.)  But since the admin app is meant to work out-of-the-box *without* customization, it's better for this to be handled by the widget.
