### PR TITLE
init_tinymce.js: add `media_url_resolver` function

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -17,6 +17,7 @@
         'paste_preprocess',
         'setup',
         'urlconverter_callback',
+        'media_url_resolver',
       ];
       fns.forEach((fn_name) => {
         if (typeof mce_conf[fn_name] != 'undefined') {


### PR DESCRIPTION
Add `media_url_resolver` to the list of function, so it will be JS evaluated, if present.

From https://www.tiny.cloud/docs/tinymce/latest/media/#media_url_resolver:
> This option allows you to specify a function that will be used to replace TinyMCE’s default media embed logic with your own, custom logic.

